### PR TITLE
Use verification button instead of command with `modals` for verification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,40 +12,34 @@
         "@discordjs/rest": "^0.4.1",
         "colorts": "^0.1.63",
         "discord-api-types": "^0.31.2",
-        "discord.js": "^13.6.0",
+        "discord.js": "^13.7.0",
         "node-tesseract-ocr": "^2.2.1",
         "ts-node-dev": "^1.1.8",
         "typescript": "^4.6.3"
       }
     },
     "node_modules/@discordjs/builders": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.11.0.tgz",
-      "integrity": "sha512-ZTB8yJdJKrKlq44dpWkNUrAtEJEq0gqpb7ASdv4vmq6/mZal5kOv312hQ56I/vxwMre+VIkoHquNUAfnTbiYtg==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.13.0.tgz",
+      "integrity": "sha512-4L9y26KRNNU8Y7J78SRUN1Uhava9D8jfit/YqEaKi8gQRc7PdqKqk2poybo6RXaiyt/BgKYPfcjxT7WvzGfYCA==",
+      "deprecated": "no longer supported",
       "dependencies": {
-        "@sindresorhus/is": "^4.2.0",
-        "discord-api-types": "^0.26.0",
-        "ts-mixer": "^6.0.0",
-        "tslib": "^2.3.1",
-        "zod": "^3.11.6"
+        "@sapphire/shapeshift": "^2.0.0",
+        "@sindresorhus/is": "^4.6.0",
+        "discord-api-types": "^0.31.1",
+        "fast-deep-equal": "^3.1.3",
+        "ts-mixer": "^6.0.1",
+        "tslib": "^2.3.1"
       },
       "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@discordjs/builders/node_modules/discord-api-types": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.26.1.tgz",
-      "integrity": "sha512-T5PdMQ+Y1MEECYMV5wmyi9VEYPagEDEi4S0amgsszpWY0VB9JJ/hEvM6BgLhbdnKky4gfmZEXtEEtojN8ZKJQQ==",
-      "engines": {
-        "node": ">=12"
+        "node": ">=16.9.0"
       }
     },
     "node_modules/@discordjs/collection": {
-      "version": "0.7.0-dev.1650240530-9ef7ffd",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.7.0-dev.1650240530-9ef7ffd.tgz",
-      "integrity": "sha512-ZlKLarDVr2jMHCyaaA30s9dWhfj/oUXZfts8m04bG+7efUUNFx1U01Zf4N8GsPSszX9RiMPkCe5zUPsv1hmJbQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.7.0.tgz",
+      "integrity": "sha512-R5i8Wb8kIcBAFEPLLf7LVBQKBDYUL+ekb23sOgpkpyGT+V4P7V83wTxcsqmX+PbqHt4cEHn053uMWfRqh/Z/nA==",
+      "deprecated": "no longer supported",
       "engines": {
         "node": ">=16.9.0"
       }
@@ -74,11 +68,20 @@
       "integrity": "sha512-Ekq1ICNpOTVajXKZguNFrsDeTmam+ZeA38txsNLZnANdXUjU6QBPIZLUQTC6MzigFGb0Tt8vk4xLnXmzv0shNg=="
     },
     "node_modules/@sapphire/async-queue": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.3.1.tgz",
-      "integrity": "sha512-FFTlPOWZX1kDj9xCAsRzH5xEJfawg1lNoYAA+ecOWJMHOfiZYb1uXOI3ne9U4UILSEPwfE68p3T9wUHwIQfR0g==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.0.tgz",
+      "integrity": "sha512-JkLdIsP8fPAdh9ZZjrbHWR/+mZj0wvKS5ICibcLrRI1j84UmLMshx5n9QmL8b95d4onJ2xxiyugTgSAX7AalmA==",
       "engines": {
         "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sapphire/shapeshift": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-2.2.0.tgz",
+      "integrity": "sha512-UEnKgMlQyI0yY/q+lCMX0VJft9y86IsesgbIQj6e62FBYSaMVr+IaMNpi4z45Q14VnuMACbK0yrbHISNqgUYcQ==",
+      "engines": {
+        "node": ">=v15.0.0",
         "npm": ">=7.0.0"
       }
     },
@@ -108,9 +111,9 @@
       "integrity": "sha512-wANk6fBrUwdpY4isjWrKTufkrXdu1D2YHCot2fD/DfWxF5sMrVSA+KN7ydckvaTCh0HiqX9IVl0L5/ZoXg5M7w=="
     },
     "node_modules/@types/node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-oMqjURCaxoSIsHSr1E47QHzbmzNR5rK8McHuNb11BOM9cHcIK3Avy0s/b2JlXHoQGTYS3NsvWzV1M0iK7l0wbA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
       "dependencies": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -284,19 +287,20 @@
       "integrity": "sha512-gpzXTvFVg7AjKVVJFH0oJGC0q0tO34iJGSHZNz9u3aqLxlD6LfxEs9wWVVikJqn9gra940oUTaPFizCkRDcEiA=="
     },
     "node_modules/discord.js": {
-      "version": "13.6.0",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.6.0.tgz",
-      "integrity": "sha512-tXNR8zgsEPxPBvGk3AQjJ9ljIIC6/LOPjzKwpwz8Y1Q2X66Vi3ZqFgRHYwnHKC0jC0F+l4LzxlhmOJsBZDNg9g==",
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.7.0.tgz",
+      "integrity": "sha512-iV/An3FEB/CiBGdjWHRtgskM4UuWPq5vjhjKsrQhdVU16dbKrBxA+eIV2HWA07B3tXUGM6eco1wkr42gxxV1BA==",
+      "deprecated": "no longer supported",
       "dependencies": {
-        "@discordjs/builders": "^0.11.0",
-        "@discordjs/collection": "^0.4.0",
-        "@sapphire/async-queue": "^1.1.9",
-        "@types/node-fetch": "^2.5.12",
-        "@types/ws": "^8.2.2",
-        "discord-api-types": "^0.26.0",
+        "@discordjs/builders": "^0.13.0",
+        "@discordjs/collection": "^0.6.0",
+        "@sapphire/async-queue": "^1.3.1",
+        "@types/node-fetch": "^2.6.1",
+        "@types/ws": "^8.5.3",
+        "discord-api-types": "^0.30.0",
         "form-data": "^4.0.0",
         "node-fetch": "^2.6.1",
-        "ws": "^8.4.0"
+        "ws": "^8.6.0"
       },
       "engines": {
         "node": ">=16.6.0",
@@ -304,21 +308,18 @@
       }
     },
     "node_modules/discord.js/node_modules/@discordjs/collection": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.4.0.tgz",
-      "integrity": "sha512-zmjq+l/rV35kE6zRrwe8BHqV78JvIh2ybJeZavBi5NySjWXqN3hmmAKg7kYMMXSeiWtSsMoZ/+MQi0DiQWy2lw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.6.0.tgz",
+      "integrity": "sha512-Ieaetb36l0nmAS5X9Upqk4W7euAO6FdXPxn3I8vBAKEcoIzEZI1mcVcPfCfagGJZSgBKpENnAnKkP4GAn+MV8w==",
+      "deprecated": "no longer supported",
       "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
+        "node": ">=16.9.0"
       }
     },
     "node_modules/discord.js/node_modules/discord-api-types": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.26.1.tgz",
-      "integrity": "sha512-T5PdMQ+Y1MEECYMV5wmyi9VEYPagEDEi4S0amgsszpWY0VB9JJ/hEvM6BgLhbdnKky4gfmZEXtEEtojN8ZKJQQ==",
-      "engines": {
-        "node": ">=12"
-      }
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.30.0.tgz",
+      "integrity": "sha512-wYst0jrT8EJs2tVlwUTQ2xT0oWMjUrRMpFTkNY3NMleWyQNHgWaKhqFfxdLPdC2im9IuR5EsxcEgjhf/npeftw=="
     },
     "node_modules/dynamic-dedupe": {
       "version": "0.3.0",
@@ -327,6 +328,11 @@
       "dependencies": {
         "xtend": "^4.0.0"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
@@ -778,9 +784,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "node_modules/typescript": {
       "version": "4.6.3",
@@ -814,9 +820,9 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "node_modules/ws": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
-      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.10.0.tgz",
+      "integrity": "sha512-+s49uSmZpvtAsd2h37vIPy1RBusaLawVe8of+GyEPsaJTCMpj/2v8NpeK1SHXjBlQ95lQTmQofOJnFiLoaN3yw==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -848,40 +854,26 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/zod": {
-      "version": "3.14.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.14.4.tgz",
-      "integrity": "sha512-U9BFLb2GO34Sfo9IUYp0w3wJLlmcyGoMd75qU9yf+DrdGA4kEx6e+l9KOkAlyUO0PSQzZCa3TR4qVlcmwqSDuw==",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
     }
   },
   "dependencies": {
     "@discordjs/builders": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.11.0.tgz",
-      "integrity": "sha512-ZTB8yJdJKrKlq44dpWkNUrAtEJEq0gqpb7ASdv4vmq6/mZal5kOv312hQ56I/vxwMre+VIkoHquNUAfnTbiYtg==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.13.0.tgz",
+      "integrity": "sha512-4L9y26KRNNU8Y7J78SRUN1Uhava9D8jfit/YqEaKi8gQRc7PdqKqk2poybo6RXaiyt/BgKYPfcjxT7WvzGfYCA==",
       "requires": {
-        "@sindresorhus/is": "^4.2.0",
-        "discord-api-types": "^0.26.0",
-        "ts-mixer": "^6.0.0",
-        "tslib": "^2.3.1",
-        "zod": "^3.11.6"
-      },
-      "dependencies": {
-        "discord-api-types": {
-          "version": "0.26.1",
-          "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.26.1.tgz",
-          "integrity": "sha512-T5PdMQ+Y1MEECYMV5wmyi9VEYPagEDEi4S0amgsszpWY0VB9JJ/hEvM6BgLhbdnKky4gfmZEXtEEtojN8ZKJQQ=="
-        }
+        "@sapphire/shapeshift": "^2.0.0",
+        "@sindresorhus/is": "^4.6.0",
+        "discord-api-types": "^0.31.1",
+        "fast-deep-equal": "^3.1.3",
+        "ts-mixer": "^6.0.1",
+        "tslib": "^2.3.1"
       }
     },
     "@discordjs/collection": {
-      "version": "0.7.0-dev.1650240530-9ef7ffd",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.7.0-dev.1650240530-9ef7ffd.tgz",
-      "integrity": "sha512-ZlKLarDVr2jMHCyaaA30s9dWhfj/oUXZfts8m04bG+7efUUNFx1U01Zf4N8GsPSszX9RiMPkCe5zUPsv1hmJbQ=="
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.7.0.tgz",
+      "integrity": "sha512-R5i8Wb8kIcBAFEPLLf7LVBQKBDYUL+ekb23sOgpkpyGT+V4P7V83wTxcsqmX+PbqHt4cEHn053uMWfRqh/Z/nA=="
     },
     "@discordjs/rest": {
       "version": "0.4.1",
@@ -906,9 +898,14 @@
       }
     },
     "@sapphire/async-queue": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.3.1.tgz",
-      "integrity": "sha512-FFTlPOWZX1kDj9xCAsRzH5xEJfawg1lNoYAA+ecOWJMHOfiZYb1uXOI3ne9U4UILSEPwfE68p3T9wUHwIQfR0g=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.0.tgz",
+      "integrity": "sha512-JkLdIsP8fPAdh9ZZjrbHWR/+mZj0wvKS5ICibcLrRI1j84UmLMshx5n9QmL8b95d4onJ2xxiyugTgSAX7AalmA=="
+    },
+    "@sapphire/shapeshift": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-2.2.0.tgz",
+      "integrity": "sha512-UEnKgMlQyI0yY/q+lCMX0VJft9y86IsesgbIQj6e62FBYSaMVr+IaMNpi4z45Q14VnuMACbK0yrbHISNqgUYcQ=="
     },
     "@sapphire/snowflake": {
       "version": "3.2.1",
@@ -926,9 +923,9 @@
       "integrity": "sha512-wANk6fBrUwdpY4isjWrKTufkrXdu1D2YHCot2fD/DfWxF5sMrVSA+KN7ydckvaTCh0HiqX9IVl0L5/ZoXg5M7w=="
     },
     "@types/node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-oMqjURCaxoSIsHSr1E47QHzbmzNR5rK8McHuNb11BOM9cHcIK3Avy0s/b2JlXHoQGTYS3NsvWzV1M0iK7l0wbA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==",
       "requires": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -1069,30 +1066,30 @@
       "integrity": "sha512-gpzXTvFVg7AjKVVJFH0oJGC0q0tO34iJGSHZNz9u3aqLxlD6LfxEs9wWVVikJqn9gra940oUTaPFizCkRDcEiA=="
     },
     "discord.js": {
-      "version": "13.6.0",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.6.0.tgz",
-      "integrity": "sha512-tXNR8zgsEPxPBvGk3AQjJ9ljIIC6/LOPjzKwpwz8Y1Q2X66Vi3ZqFgRHYwnHKC0jC0F+l4LzxlhmOJsBZDNg9g==",
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.7.0.tgz",
+      "integrity": "sha512-iV/An3FEB/CiBGdjWHRtgskM4UuWPq5vjhjKsrQhdVU16dbKrBxA+eIV2HWA07B3tXUGM6eco1wkr42gxxV1BA==",
       "requires": {
-        "@discordjs/builders": "^0.11.0",
-        "@discordjs/collection": "^0.4.0",
-        "@sapphire/async-queue": "^1.1.9",
-        "@types/node-fetch": "^2.5.12",
-        "@types/ws": "^8.2.2",
-        "discord-api-types": "^0.26.0",
+        "@discordjs/builders": "^0.13.0",
+        "@discordjs/collection": "^0.6.0",
+        "@sapphire/async-queue": "^1.3.1",
+        "@types/node-fetch": "^2.6.1",
+        "@types/ws": "^8.5.3",
+        "discord-api-types": "^0.30.0",
         "form-data": "^4.0.0",
         "node-fetch": "^2.6.1",
-        "ws": "^8.4.0"
+        "ws": "^8.6.0"
       },
       "dependencies": {
         "@discordjs/collection": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.4.0.tgz",
-          "integrity": "sha512-zmjq+l/rV35kE6zRrwe8BHqV78JvIh2ybJeZavBi5NySjWXqN3hmmAKg7kYMMXSeiWtSsMoZ/+MQi0DiQWy2lw=="
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.6.0.tgz",
+          "integrity": "sha512-Ieaetb36l0nmAS5X9Upqk4W7euAO6FdXPxn3I8vBAKEcoIzEZI1mcVcPfCfagGJZSgBKpENnAnKkP4GAn+MV8w=="
         },
         "discord-api-types": {
-          "version": "0.26.1",
-          "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.26.1.tgz",
-          "integrity": "sha512-T5PdMQ+Y1MEECYMV5wmyi9VEYPagEDEi4S0amgsszpWY0VB9JJ/hEvM6BgLhbdnKky4gfmZEXtEEtojN8ZKJQQ=="
+          "version": "0.30.0",
+          "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.30.0.tgz",
+          "integrity": "sha512-wYst0jrT8EJs2tVlwUTQ2xT0oWMjUrRMpFTkNY3NMleWyQNHgWaKhqFfxdLPdC2im9IuR5EsxcEgjhf/npeftw=="
         }
       }
     },
@@ -1103,6 +1100,11 @@
       "requires": {
         "xtend": "^4.0.0"
       }
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fill-range": {
       "version": "7.0.1",
@@ -1412,9 +1414,9 @@
       }
     },
     "tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
     },
     "typescript": {
       "version": "4.6.3",
@@ -1441,9 +1443,9 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
-      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.10.0.tgz",
+      "integrity": "sha512-+s49uSmZpvtAsd2h37vIPy1RBusaLawVe8of+GyEPsaJTCMpj/2v8NpeK1SHXjBlQ95lQTmQofOJnFiLoaN3yw==",
       "requires": {}
     },
     "xtend": {
@@ -1455,11 +1457,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
-    },
-    "zod": {
-      "version": "3.14.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.14.4.tgz",
-      "integrity": "sha512-U9BFLb2GO34Sfo9IUYp0w3wJLlmcyGoMd75qU9yf+DrdGA4kEx6e+l9KOkAlyUO0PSQzZCa3TR4qVlcmwqSDuw=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@discordjs/rest": "^0.4.1",
     "colorts": "^0.1.63",
     "discord-api-types": "^0.31.2",
-    "discord.js": "^13.6.0",
+    "discord.js": "^13.7.0",
     "node-tesseract-ocr": "^2.2.1",
     "ts-node-dev": "^1.1.8",
     "typescript": "^4.6.3"

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -1,16 +1,10 @@
 import { SlashCommandBuilder } from '@discordjs/builders';
 import { CommandInteraction, GuildMemberRoleManager, RoleManager } from 'discord.js';
-import crypto from 'crypto';
 import Logger from '../util/Logger';
-import config from '../config.json';
+import verificationModal from '../util/verificationModal';
 const c = new Logger('/verify');
 
 async function run(interaction: CommandInteraction) {
-    const password = config.support_password_hash; // You're hopeless if you checked here for the password.
-    const hash = crypto.createHash('md5');
-    const input = interaction.options.getString('password', true);
-    const hashedInput = hash.update(input).digest('hex');
-    const verifiedRole = (interaction.guild?.roles as RoleManager).cache.get('978201137972912198');
     const hasVerified = (interaction.member!.roles as GuildMemberRoleManager).cache.some(r => r.name === "Verified");
 
     c.log(`User ${interaction.member?.user.username || "???"}#${interaction.member?.user.discriminator || "0000"} is verifying`);
@@ -23,29 +17,12 @@ async function run(interaction: CommandInteraction) {
         return;
     }
 
-    if (hashedInput === password) {
-        c.trail(`Verified successfully`);
-        if (verifiedRole) {
-            (interaction.member?.roles as GuildMemberRoleManager).add(verifiedRole);
-            interaction.reply({
-                content: `You've been verified!`,
-                ephemeral: true,
-            });
-        }
-    } else {
-        c.trail(`Incorrect password: ${input} | ${hashedInput} != ${password}`);
-        interaction.reply({
-            content: `Incorrect password.`,
-            ephemeral: true,
-        });
-        return;
-    }
+    interaction.showModal(verificationModal);
 }
 
 const cmd = new SlashCommandBuilder()
     .setName('verify')
     .setDescription('Access the support channels')
-    .addStringOption(o => o.setName('password').setDescription(`Password from the wiki`).setRequired(true))
 
 let _;
 export default _ = {

--- a/src/db/verificationMessages.json
+++ b/src/db/verificationMessages.json
@@ -2,81 +2,81 @@
     {
         "lang_code": "lt",
         "title": "Sveiki atvyke į Grasscutter!",
-        "content": "Kad pasiekti kitus kanalus, neįskaitant pagalbos kanalus, prašome patvirtinti save naudojant `/verify <password>` komandą. Slaptažodis yra paslpėptas wiki. \n\nJei turite problemų patvirtiname, prašome susisiekti su moderatoriumi"
+        "content": "Kad pasiekti kitus kanalus, neįskaitant pagalbos kanalus, prašome patvirtinti save naudojant `/verify` komandą. Slaptažodis yra paslpėptas wiki. \n\nJei turite problemų patvirtiname, prašome susisiekti su moderatoriumi"
     },
     {
         "lang_code": "tr",
         "title": "Grasscutter'a hoşgeldin!",
-        "content": "Destek kanalları dışındaki kanallara erişmek için, Lütfen `/verify <şifre>` komutunu kullanarak kendinizi doğrulayın. Şifre Wiki'de gizli.\n\nEğer doğrulama hakkında herhangi bir sorununuz varsa, lütfen bir moderatöre ulaşın ."
+        "content": "Destek kanalları dışındaki kanallara erişmek için, Lütfen `/verify` komutunu kullanarak kendinizi doğrulayın. Şifre Wiki'de gizli.\n\nEğer doğrulama hakkında herhangi bir sorununuz varsa, lütfen bir moderatöre ulaşın ."
     },
     {
         "lang_code": "ge",
         "title": "მობრძანდით Grasscutter-ში!",
-        "content": "თუ გინდათ რომ support-ის გარდა სხვა არხები ნახოთ, გთხოვთ გადაამოწმეთ საკუთარი თავი `/verify <password>` ბრძანებით. პაროლი არის დამალული ვიკიში.\n\nთუ გაქვთ პრობლემები გადამოწმებაში, გთხოვთ ადმინისტრატორს დაუკავშირდით."
+        "content": "თუ გინდათ რომ support-ის გარდა სხვა არხები ნახოთ, გთხოვთ გადაამოწმეთ საკუთარი თავი `/verify` ბრძანებით. პაროლი არის დამალული ვიკიში.\n\nთუ გაქვთ პრობლემები გადამოწმებაში, გთხოვთ ადმინისტრატორს დაუკავშირდით."
     },
     {
         "lang_code": "ro",
         "title": "Bine ati venit la Grasscutter!",
-        "content": "Ca sa puteti accesa si alte canale inafara de cele de suport, va rugam sa va verificati folosind comanda `/verify <parola>` . Parola este ascunsa in wiki.\n\nDaca aveti probleme in procesul de verificare, va rugam sa contactati un moderator."
+        "content": "Ca sa puteti accesa si alte canale inafara de cele de suport, va rugam sa va verificati folosind comanda `/verify` . Parola este ascunsa in wiki.\n\nDaca aveti probleme in procesul de verificare, va rugam sa contactati un moderator."
     },
     {
         "lang_code": "kr",
         "title": "Grasscutter에 오신것을 환영합니다!",
-        "content": "support 채널을 제외한 다른 채널에 접근하시려면, `/verify <비밀번호` 명령어를 사용하여 인증하세요. 비밀번호는 위키에 숨겨져 있습니다.\n\n만약 인증하는 데 문제가 있다면, 모더레이터에게 연락해주세요."
+        "content": "support 채널을 제외한 다른 채널에 접근하시려면, `/verify` 명령어를 사용하여 인증하세요. 비밀번호는 위키에 숨겨져 있습니다.\n\n만약 인증하는 데 문제가 있다면, 모더레이터에게 연락해주세요."
     },
     {
         "lang_code": "pl",
         "title": "Witamy w Grasscutter!",
-        "content": "Aby otrzymać dostęp do innych kanałów niż support, proszę zweryfikować się za pomocą komendy  `/verify <hasło>`. Hasło jest ukryte gdzieś w wiki.\n\nJeśli masz problem z weryfikacją, proszę skontaktować się z moderatorem."
+        "content": "Aby otrzymać dostęp do innych kanałów niż support, proszę zweryfikować się za pomocą komendy  `/verify`. Hasło jest ukryte gdzieś w wiki.\n\nJeśli masz problem z weryfikacją, proszę skontaktować się z moderatorem."
     },
     {
         "lang_code": "it",
         "title": "Benvenuto in  Grasscutter!",
-        "content": "Per accedere ad altri canali oltre a quelli di supporto, ti preghiamo di verificarti usando il comando `/verify <password>` . La password è nascosta nella Wiki .\n\n se riscontri qualsiasi problema durante la verifica ti preghiamo di contattare un moderatore."
+        "content": "Per accedere ad altri canali oltre a quelli di supporto, ti preghiamo di verificarti usando il comando `/verify` . La password è nascosta nella Wiki .\n\n se riscontri qualsiasi problema durante la verifica ti preghiamo di contattare un moderatore."
     },
     {
         "lang_code": "de",
         "title": "Willkommen bei Grasscutter!",
-        "content": "Um Zugriff auf andere Kanäle als nur support Kanäle zu bekommen, verifiziere dich bitte indem du den  `/verify <passwort>` Befehl benutzt. Das Passwort ist in der wiki versteckt.\n\nSolltest du Probleme beim verifizieren haben, bitte kontaktiere einen Moderator."
+        "content": "Um Zugriff auf andere Kanäle als nur support Kanäle zu bekommen, verifiziere dich bitte indem du den  `/verify` Befehl benutzt. Das Passwort ist in der wiki versteckt.\n\nSolltest du Probleme beim verifizieren haben, bitte kontaktiere einen Moderator."
     },
     {
         "lang_code": "fr",
         "title": "Bienvenue dans Grasscutter!",
-        "content": "Pour accéder aux salons autre que ceux de support, veuillez vous vérifier en utilisant la commande `/verify <mot_de_passe>`. Le mot de passe est caché dans le wiki.\n\n Si vous avez des problèmes avec la vérification, veuillez contacter un modérateur."
+        "content": "Pour accéder aux salons autre que ceux de support, veuillez vous vérifier en utilisant la commande `/verify`. Le mot de passe est caché dans le wiki.\n\n Si vous avez des problèmes avec la vérification, veuillez contacter un modérateur."
     },
     {
         "lang_code": "es",
         "title": "Bienvenido a Grasscutter!",
-        "content": "Para acceder a otros canales que no sean canales de suporte, verificate usando el comando `/verify <password>`. La contraseña está oculta en la wiki.\n\nSi tienes problemas verificandote, contacta con un moderador."
+        "content": "Para acceder a otros canales que no sean canales de suporte, verificate usando el comando `/verify`. La contraseña está oculta en la wiki.\n\nSi tienes problemas verificandote, contacta con un moderador."
     },
     {
         "lang_code": "vn",
         "title": "Chào mừng bạn đã đến với Grasscutter!",
-        "content": "Để có thể truy cập các kênh khác ngoài các kênh dành cho support, hãy xác minh bản thân bạn bằng cách sử dụng lệnh `/verify <password>`. Mật khẩu được ẩn giấu ở trong Wiki.\n\nNếu bạn có vấn đề gì liên quan tới phần xác minh, vui lòng liên hệ quản trị viên để có thể nhận sự trợ giúp."
+        "content": "Để có thể truy cập các kênh khác ngoài các kênh dành cho support, hãy xác minh bản thân bạn bằng cách sử dụng lệnh `/verify`. Mật khẩu được ẩn giấu ở trong Wiki.\n\nNếu bạn có vấn đề gì liên quan tới phần xác minh, vui lòng liên hệ quản trị viên để có thể nhận sự trợ giúp."
     },
     {
         "lang_code": "ua",
         "title": "Ласкаво просимо до Grasscutter!",
-        "content": "Щоб отримати доступ до інших каналів, окрім каналів підтримки, будь ласка, авторизуйтесь за допомогою команди `/verify <пароль>`. Пароль приховано у вікі.\n\nЯкщо у вас виникли проблеми з верифікацією, будь ласка, зверніться до модератора."
+        "content": "Щоб отримати доступ до інших каналів, окрім каналів підтримки, будь ласка, авторизуйтесь за допомогою команди `/verify`. Пароль приховано у вікі.\n\nЯкщо у вас виникли проблеми з верифікацією, будь ласка, зверніться до модератора."
     },
     {
         "lang_code": "br",
         "title": "Bem-vindo ao Grasscutter!",
-        "content": "Pra acessar outros canais além dos canais de suporte, por favor verifique-se usando o comando `/verify <senha>`. A senha está escondida na wiki.\n\nSe você tiver algum problema ao verificar, contate um moderador. "
+        "content": "Pra acessar outros canais além dos canais de suporte, por favor verifique-se usando o comando `/verify`. A senha está escondida na wiki.\n\nSe você tiver algum problema ao verificar, contate um moderador. "
     },
     {
         "lang_code": "ru",
         "title": "Добро пожаловать в Grasscutter!",
-        "content": "Чтобы получить доступ к другим каналам кроме поддержки, пожалуйста, подтвердите себя используя команду `/verify <пароль>`. Пароль спрятан в вики.\n\nЕсли вы столкнётесь с проблемами во время подтверждения, пожалуйста, свяжитесь с модератором."
+        "content": "Чтобы получить доступ к другим каналам кроме поддержки, пожалуйста, подтвердите себя используя команду `/verify`. Пароль спрятан в вики.\n\nЕсли вы столкнётесь с проблемами во время подтверждения, пожалуйста, свяжитесь с модератором."
     },
     {
         "lang_code": "cn",
         "title": "欢迎来到 Grasscutter!",
-        "content": "要访问支持频道以外的其他频道, 请使用 `/verify <密码>` 命令验证自己。密码隐藏在 wiki 中。如果您在验证时遇到任何问题，请联系版主。"
+        "content": "要访问支持频道以外的其他频道, 请使用 `/verify` 命令验证自己。密码隐藏在 wiki 中。如果您在验证时遇到任何问题，请联系版主。"
     },
     {
         "lang_code": "us",
         "title": "Welcome to Grasscutter!",
-        "content": "To access other channels than support channels, please verify yourself by using the `/verify <password>` command. The password is hidden in the wiki.\n\nIf you have any issues verifying, please contact a moderator."
+        "content": "To access other channels than support channels, please verify yourself by using the `/verify` command. The password is hidden in the wiki.\n\nIf you have any issues verifying, please contact a moderator."
     }
 ]

--- a/src/db/verificationMessages.json
+++ b/src/db/verificationMessages.json
@@ -7,13 +7,11 @@
     {
         "lang_code": "lt",
         "title": "Sveiki atvyke į Grasscutter!",
-        "content": "Kad pasiekti kitus kanalus, neįskaitant pagalbos kanalus, prašome patvirtinti save naudojant `/verify <password>` komandą. Slaptažodis yra paslpėptas wiki. \n\nJei turite problemų patvirtiname, prašome susisiekti su moderatoriumi"
         "content": "Kad pasiekti kitus kanalus, neįskaitant pagalbos kanalus, prašome patvirtinti save naudojant `/verify <password>` komandą. Slaptažodis yra paslpėptas wiki. \n\nJei turite problemų patvirtiname, prašome susisiekti su moderatoriumi."
     },
     {
         "lang_code": "tr",
         "title": "Grasscutter'a hoşgeldin!",
-        "content": "Destek kanalları dışındaki kanallara erişmek için, Lütfen `/verify <şifre>` komutunu kullanarak kendinizi doğrulayın. Şifre Wiki'de gizli.\n\nEğer doğrulama hakkında herhangi bir sorununuz varsa, lütfen bir moderatöre ulaşın ."
         "content": "Destek kanalları dışındaki kanallara erişmek için, Lütfen `/verify <şifre>` komutunu kullanarak kendinizi doğrulayın. Şifre Wiki'de gizli.\n\nEğer doğrulama hakkında herhangi bir sorununuz varsa, lütfen bir moderatöre ulaşın."
     },
     {
@@ -23,8 +21,6 @@
     },
     {
         "lang_code": "ro",
-        "title": "Bine ati venit la Grasscutter!",
-        "content": "Ca sa puteti accesa si alte canale inafara de cele de suport, va rugam sa va verificati folosind comanda `/verify <parola>` . Parola este ascunsa in wiki.\n\nDaca aveti probleme in procesul de verificare, va rugam sa contactati un moderator."
         "title": "Bine ați venit la Grasscutter!",
         "content": "Ca să puteți accesa și alte canale înafară de cele de suport, vă rugăm să vă verificați folosind comanda `/verify <parola>` . Parola este ascunsă în wiki.\n\nDacă aveți probleme în procesul de verificare, vă rugăm să contactați un moderator."
     },

--- a/src/events/button.ts
+++ b/src/events/button.ts
@@ -1,10 +1,9 @@
-import { SlashCommandBuilder } from '@discordjs/builders';
-import { CommandInteraction, GuildMemberRoleManager, RoleManager } from 'discord.js';
-import Logger from '../util/Logger';
+import { ButtonInteraction, GuildMemberRoleManager } from "discord.js";
 import verificationModal from '../util/verificationModal';
-const c = new Logger('/verify');
+import Logger from '../util/Logger';
+const c = new Logger('verification');
 
-async function run(interaction: CommandInteraction) {
+export default async function run(interaction: ButtonInteraction) {
     const hasVerified = (interaction.member!.roles as GuildMemberRoleManager).cache.some(r => r.name === "Verified");
 
     c.log(`User ${interaction.member?.user.username || "???"}#${interaction.member?.user.discriminator || "0000"} is verifying`);
@@ -18,14 +17,4 @@ async function run(interaction: CommandInteraction) {
     }
 
     interaction.showModal(verificationModal);
-}
-
-const cmd = new SlashCommandBuilder()
-    .setName('verify')
-    .setDescription('Access the support channels')
-
-let _;
-export default _ = {
-    process: run,
-    command: cmd
 }

--- a/src/events/modalSubmit.ts
+++ b/src/events/modalSubmit.ts
@@ -1,0 +1,31 @@
+import { ModalSubmitInteraction, RoleManager, GuildMemberRoleManager } from "discord.js"; 'discord.js';
+import crypto from 'crypto';
+import config from '../config.json';
+import Logger from '../util/Logger';
+const c = new Logger('modalSubmit');
+
+export default async function verify(interaction: ModalSubmitInteraction) {
+    const password = config.support_password_hash; // You're hopeless if you checked here for the password.
+    const hash = crypto.createHash('md5');
+    const verifiedRole = (interaction.guild?.roles as RoleManager).cache.get('978201137972912198');
+    const input = interaction.fields.getTextInputValue('password-input');
+    const hashedInput = hash.update(input).digest('hex');
+
+    if (hashedInput === password) {
+        c.trail(`Verified successfully`);
+        if (verifiedRole) {
+            (interaction.member?.roles as GuildMemberRoleManager).add(verifiedRole);
+            interaction.reply({
+                content: `You've been verified!`,
+                ephemeral: true,
+            });
+        }
+    } else {
+        c.trail(`Incorrect password: ${input} | ${hashedInput} != ${password}`);
+        interaction.reply({
+            content: `Incorrect password.`,
+            ephemeral: true,
+        });
+        return;
+    }
+}

--- a/src/events/modalSubmit.ts
+++ b/src/events/modalSubmit.ts
@@ -1,4 +1,4 @@
-import { ModalSubmitInteraction, RoleManager, GuildMemberRoleManager } from "discord.js"; 'discord.js';
+import { ModalSubmitInteraction, RoleManager, GuildMemberRoleManager } from "discord.js";
 import crypto from 'crypto';
 import config from '../config.json';
 import Logger from '../util/Logger';

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ client.on('interactionCreate', async (interaction) => {
         if (interaction.customId === 'verification-modal') {
             verify(interaction);
         }
-    }
+    } else return;
 });
 
 client.on('messageCreate', async (message) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import getConfig from './util/config';
 import register from './util/registercommands';
 import getEvents, { findEvent } from './events/eventHandler';
 import verify from './events/modalSubmit';
+import verifyInit from './events/button';
 import { Routes } from 'discord-api-types/v10';
 import Logger from './util/Logger';
 const c = new Logger('Lawnmower');
@@ -41,7 +42,11 @@ client.on('interactionCreate', async (interaction) => {
         if (interaction.customId === 'verification-modal') {
             verify(interaction);
         }
-    } else return;
+    } else if(interaction.isButton()) {
+        if(interaction.customId === 'verification-button') {
+            verifyInit(interaction);
+        }
+    }
 });
 
 client.on('messageCreate', async (message) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { Client, Guild, Intents } from 'discord.js';
 import getConfig from './util/config';
 import register from './util/registercommands';
 import getEvents, { findEvent } from './events/eventHandler';
+import verify from './events/modalSubmit';
 import { Routes } from 'discord-api-types/v10';
 import Logger from './util/Logger';
 const c = new Logger('Lawnmower');
@@ -26,16 +27,21 @@ async function registerEvent(event: string, ...args: any) {
 }
 
 client.on('interactionCreate', async (interaction) => {
-    if (!interaction.isCommand()) return;
-    ci.log(`/${interaction.commandName} was called by ${interaction.user.username}#${interaction.user.discriminator}`);
-    import(`./commands/${interaction.commandName}`).then(async (cmd) => {
-        await cmd.default.process(interaction);
-    }).catch(async (error) => {
-        c.error(error as unknown as Error);
-        import('./commands/cmd').then(async (cmd) => {
+    if (interaction.isCommand()) {
+        ci.log(`/${interaction.commandName} was called by ${interaction.user.username}#${interaction.user.discriminator}`);
+        import(`./commands/${interaction.commandName}`).then(async (cmd) => {
             await cmd.default.process(interaction);
+        }).catch(async (error) => {
+            c.error(error as unknown as Error);
+            import('./commands/cmd').then(async (cmd) => {
+                await cmd.default.process(interaction);
+            });
         });
-    });
+    } else if (interaction.isModalSubmit()) {
+        if (interaction.customId === 'verification-modal') {
+            verify(interaction);
+        }
+    }
 });
 
 client.on('messageCreate', async (message) => {

--- a/src/util/verificationMessages.ts
+++ b/src/util/verificationMessages.ts
@@ -1,10 +1,18 @@
-import { CommandInteraction, MessageEmbed, TextChannel } from 'discord.js';
+import { CommandInteraction, MessageEmbed, TextChannel, MessageActionRow, MessageButton } from 'discord.js';
 import vm from '../db/verificationMessages.json';
 import Logger from './Logger';
 const c = new Logger(`verificationMessages`);
 
+const verificationRow = new MessageActionRow()
+    .addComponents(
+        new MessageButton()
+            .setCustomId('verification-button')
+            .setLabel('Verify')
+            .setStyle('SUCCESS')
+    );
+
 export default async function run(interaction: CommandInteraction, specify?: string) {
-    vm.forEach(v => {
+    vm.forEach((v, idx, arr) => {
         if (specify && v.lang_code != specify) return;
 
         const embed = new MessageEmbed();
@@ -14,9 +22,11 @@ export default async function run(interaction: CommandInteraction, specify?: str
             .setFooter({
                 text: new Date().toLocaleString()
             });
+
         (interaction.client.channels.cache.get('1028327705571238009') as TextChannel).send({
             embeds: [embed],
-            content: '** **'
+            content: '** **',
+            components: (idx == arr.length - 1) ? [verificationRow] : []
         });
     });
 }

--- a/src/util/verificationMessages.ts
+++ b/src/util/verificationMessages.ts
@@ -23,7 +23,7 @@ export default async function run(interaction: CommandInteraction, specify?: str
                 text: new Date().toLocaleString()
             });
 
-        (interaction.client.channels.cache.get('1028327705571238009') as TextChannel).send({
+        (interaction.client.channels.cache.get('970054253525733386') as TextChannel).send({
             embeds: [embed],
             content: '** **',
             components: (idx == arr.length - 1) ? [verificationRow] : []

--- a/src/util/verificationModal.ts
+++ b/src/util/verificationModal.ts
@@ -1,0 +1,16 @@
+import { MessageActionRow, Modal, TextInputComponent } from 'discord.js';
+
+const modal = new Modal()
+    .setCustomId('verification-modal')
+    .setTitle('Verify')
+
+const passwordInput = new TextInputComponent()
+    .setCustomId('password-input')
+    .setLabel('Password')
+    .setPlaceholder('Enter your password')
+    .setStyle('SHORT')
+
+const row = new MessageActionRow<TextInputComponent>().addComponents(passwordInput)
+modal.addComponents(row)
+
+export default modal;


### PR DESCRIPTION
### What's in the pr
1. Bump discord.js version to `13.7.0` to support modals
2. Add modal for verification
3. Update Verification Messages

**Note: the hash for the password is still for the old password `sponzen`. Adjust it as you want.**

**Using `verify` command will now show the verification modal where users can input the verification password**

![image](https://user-images.githubusercontent.com/104459145/200190675-da3a7a45-f002-49ea-a112-55aeac67d57f.png)
![image](https://user-images.githubusercontent.com/104459145/200190708-e99e994a-154e-4c2e-9988-6e08c1789e32.png)
![image](https://user-images.githubusercontent.com/104459145/200190714-8f8115cb-968d-404f-bc60-b6d7f387202c.png)



